### PR TITLE
Add setup-java step to install JDK 11

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2 # v2 minimum required
+      - uses: actions/setup-java@v1 # JDK 11 minimum required
+        with:
+          java-version: '11'
       - uses: axel-op/googlejavaformat-action@v2.0.0
         with:
           args: "--skip-sorting-imports --replace"


### PR DESCRIPTION
`google-java-format` released a new version [3 days ago](https://github.com/google/google-java-format/releases/tag/google-java-format-1.8) that updated the minimum supported version to JDK 11.

Using the current instructions, the action will fail due to JDK 8 being [the default](https://github.com/actions/virtual-environments/blob/ubuntu18/20200406.2/images/linux/Ubuntu1804-README.md) on `ubuntu-default` containers.