### PR TITLE
Added commit message option

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,10 @@ A pattern to match the files to format. The default is `**/*.java`, which means 
 
 Set to `true` if you don't want the changes to be committed by this action. Default: `false`.
 
+### `commitMessage`
+
+You can optionally also specify a custom commit message. Default: `Google Java Format`.
+
 ### `args`
 
 The arguments to pass to the Google Java Format executable.

--- a/action.yml
+++ b/action.yml
@@ -23,6 +23,9 @@ inputs:
   githubToken:
     description: "Recommended on MacOS machines"
     required: false
+  commitMessage:
+    description: "Optional commit message"
+    required: false
 runs:
   using: "node12"
   main: "index.js"

--- a/index.js
+++ b/index.js
@@ -7,6 +7,7 @@ const path = require('path');
 const owner = 'google';
 const repo = 'google-java-format';
 const githubToken = core.getInput('githubToken', { required: false });
+const commitMessage = core.getInput('commitMessage', { required: false });
 const executable = path.join(process.env.HOME || process.env.USERPROFILE, 'google-java-format.jar');
 const apiReleases = `https://api.github.com/repos/${owner}/${repo}/releases`;
 
@@ -158,7 +159,7 @@ async function run() {
                 await execute("git config user.email ''", { silent: true });
                 const diffIndex = await execute('git diff-index --quiet HEAD', { ignoreReturnCode: true, silent: true });
                 if (diffIndex.exitCode !== 0) {
-                    await execute('git commit --all -m "Google Java Format"');
+                    await execute(`git commit --all -m "${commitMessage ? commitMessage : 'Google Java Format'}"`);
                     await push();
                 } else core.info('Nothing to commit!')
             });


### PR DESCRIPTION
This Pull Request adds the option to also configure the commit message.
In some set ups, it may be useful to prefix commits like this with "[ci skip]" or similar to prevent cleanups like this from triggering any CI systems.

This option is not required and will fallback to the current commit message "Google Java Format".