### PR TITLE
Add functionality to change commit author to who triggered action

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,10 @@ Set to `true` if you don't want the changes to be committed by this action. Defa
 
 You can specify a custom commit message. Default: `Google Java Format`.
 
+### `commitAsAuthor`
+
+Set to `true` if you want to commit as user triggered thos workflow run. Default: `false`, commit as GitHub Actions.
+
 ### `args`
 
 The arguments to pass to the Google Java Format executable.

--- a/action.yml
+++ b/action.yml
@@ -27,6 +27,10 @@ inputs:
     description: "Commit message"
     required: false
     default: "Google Java Format"
+  commitAsAuthor:
+    description: "Set \"true\" to set commit author as the user triggered this workflow run."
+    required: false
+    default: "false"
 runs:
   using: "node12"
   main: "index.js"

--- a/index.js
+++ b/index.js
@@ -117,6 +117,17 @@ async function getReleaseId() {
     return releaseId;
 }
 
+async function getCommitAuthor() {
+    const commitAsAuthor = core.getInput('commitAsAuthor', { required: false }) === 'true' ? true : false
+
+    if (commitAsAuthor) {
+        const env = process.env;
+        return `--author=${env.GITHUB_ACTOR}" <${env.GITHUB_ACTOR}@users.noreply.github.com>"`;
+    } else {
+        return '';
+    }
+}
+
 async function push() {
     if (!githubToken) await execute('git push');
     else {
@@ -159,7 +170,8 @@ async function run() {
                 await execute("git config user.email ''", { silent: true });
                 const diffIndex = await execute('git diff-index --quiet HEAD', { ignoreReturnCode: true, silent: true });
                 if (diffIndex.exitCode !== 0) {
-                    await execute(`git commit --all -m "${commitMessage ? commitMessage : 'Google Java Format'}"`);
+                    const commitAuthor = await getCommitAuthor();
+                    await execute(`git commit --all -m "${commitMessage ? commitMessage : 'Google Java Format'}" ${commitAuthor}`);
                     await push();
                 } else core.info('Nothing to commit!')
             });


### PR DESCRIPTION
# Description
Add functionality to change commit author from `github-actions` to user who triggered the action.

Currently, all the format commits are committed as `github-actions`, and it's hard to figure out who triggered that format.
So I added option `commitAsAuthor` to change commit author to who triggered action to make clear who organized the code.
This change will not be affected to user currently using this action, it will be enabled only when users specified option.

# Example
I tested this action in my local repository, and here's the screen shots.

## case `commitAsAuthor = true`
https://github.com/pakio/KuromojiAPI/commit/7bf4a0092b4cad315b3ebf8b8c72ee06604be25c
![スクリーンショット 2021-03-21 16 32 17](https://user-images.githubusercontent.com/11995398/111897382-02e6af00-8a63-11eb-8928-968d30391f94.png)
settings are here : https://github.com/pakio/KuromojiAPI/blob/7bf4a0092b4cad315b3ebf8b8c72ee06604be25c/.github/workflows/on_push.yml#L14-L17

## case `commitAsAuthor = false (or default)`
https://github.com/pakio/KuromojiAPI/commit/bee3da2b08278714dc63c09a0ade7c29d7eb9c6d
![スクリーンショット 2021-03-21 16 34 01](https://user-images.githubusercontent.com/11995398/111897416-404b3c80-8a63-11eb-946b-d36e12d9f859.png)
settings are here : https://github.com/pakio/KuromojiAPI/blob/bee3da2b08278714dc63c09a0ade7c29d7eb9c6d/.github/workflows/on_push.yml#L14-L15

