### PR TITLE
chore: Update `actions/checkout`'s version to `v4`.

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -33,7 +33,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -8,7 +8,7 @@ jobs:
   compile-and-push:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: actions/setup-node@v3
         with:
           node-version: 16

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
         version: ["1.6", ""]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: actions/setup-java@v1
         with:
           java-version: ${{ matrix.java-version }}
@@ -37,7 +37,7 @@ jobs:
         version: ["1.6", ""]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: actions/setup-java@v1
         with:
           java-version: ${{ matrix.java-version }}

--- a/.github/workflows/validate-action-typings.yml
+++ b/.github/workflows/validate-action-typings.yml
@@ -6,5 +6,5 @@ jobs:
   validate-typings:
     runs-on: "ubuntu-latest"
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: krzema12/github-actions-typing@v0

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ jobs:
   formatting:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3 # v2 minimum required
+      - uses: actions/checkout@v4 # v2 minimum required
       - uses: axel-op/googlejavaformat-action@v3
         with:
           args: "--skip-sorting-imports --replace"
@@ -44,7 +44,7 @@ jobs:
   formatting:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3 # v2 minimum required
+      - uses: actions/checkout@v4 # v2 minimum required
       - uses: axel-op/googlejavaformat-action@v3
         with:
           args: "--set-exit-if-changed"
@@ -62,7 +62,7 @@ jobs:
   formatting:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3 # v2 minimum required
+      - uses: actions/checkout@v4 # v2 minimum required
       - uses: axel-op/googlejavaformat-action@v3
         with:
           args: "--replace"


### PR DESCRIPTION
Thank you for creating and maintaining a useful workflow!

I updated `actions/checkout`'s version to `v4` in the example in `README.md` and workflow files.

By the way, there comment are very helpful. Thanks!

- https://github.com/axel-op/googlejavaformat-action/issues/11#issuecomment-765322622
- https://github.com/axel-op/googlejavaformat-action/issues/21#issuecomment-1173055771