### PR TITLE
Make all formatter releases available

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,7 +21,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        java-version: [8, 11, 17]
+        java-version: [8, 11, 17, 21]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4

--- a/__tests__/releases.test.ts
+++ b/__tests__/releases.test.ts
@@ -46,7 +46,8 @@ const dummyReleaseData: ReleaseData = {
 
 const dummyReleaseData_1_7 = { ...dummyReleaseData, name: '1.7' };
 const dummyReleaseData_v1_24_0 = { ...dummyReleaseData, name: 'v1.24.0' };
-const allReleases = [dummyReleaseData, dummyReleaseData_1_7, dummyReleaseData_v1_24_0];
+const dummyReleaseData_v1_28_0 = { ...dummyReleaseData, name: 'v1.28.0' };
+const allReleases = [dummyReleaseData, dummyReleaseData_1_7, dummyReleaseData_v1_24_0, dummyReleaseData_v1_28_0];
 
 const executor = jest.fn<CommandExecutor>();
 type ListReleases = Octokit['rest']['repos']['listReleases'];
@@ -139,7 +140,7 @@ describe('get all release data', () => {
 });
 
 describe('get latest release data', () => {
-    const casesJavaVersions: [number, ReleaseData][] = [[8, dummyReleaseData_1_7], [11, dummyReleaseData_v1_24_0]];
+    const casesJavaVersions: [number, ReleaseData][] = [[8, dummyReleaseData_1_7], [11, dummyReleaseData_v1_24_0], [17, dummyReleaseData_v1_28_0]];
 
     describe('get latest release data with API', () => {
         const releases = new Releases(executor);

--- a/__tests__/releases.test.ts
+++ b/__tests__/releases.test.ts
@@ -105,6 +105,7 @@ function mockOctokitReturnRelease(releaseData: ReleaseData) {
 }
 
 const URL_BASE = "https://api.github.com/repos/google/google-java-format/releases";
+const URL_TAIL = "?per_page=100";
 
 describe('get all release data', () => {
     test('get all release data with API', async () => {
@@ -113,7 +114,7 @@ describe('get all release data', () => {
         const results = await releases.getAllReleaseData();
         expect(results).toEqual(allReleases);
         // IMPORTANT: should not have a trailing slash
-        expectLastCurlCallForUrl(URL_BASE);
+        expectLastCurlCallForUrl(URL_BASE + URL_TAIL);
     });
 
     test('get all release data with API and call to API fails', async () => {
@@ -124,7 +125,7 @@ describe('get all release data', () => {
             .rejects
             .toThrow(error)
         // IMPORTANT: should not have a trailing slash
-        expectLastCurlCallForUrl(URL_BASE);
+        expectLastCurlCallForUrl(URL_BASE + URL_TAIL);
     });
 
     test('get all release data with octokit', async () => {
@@ -148,14 +149,14 @@ describe('get latest release data', () => {
             const result = await releases.getLatestReleaseData(javaVersion);
             expect(result).toEqual(expectedRelease);
             // IMPORTANT: should not have a trailing slash
-            expectLastCurlCallForUrl(URL_BASE);
+            expectLastCurlCallForUrl(URL_BASE + URL_TAIL);
         });
 
         test('when java version is 21, then return release latest', async () => {
             mockApiReturnRelease(dummyReleaseData);
             const result = await releases.getLatestReleaseData(21);
             expect(result).toEqual(dummyReleaseData);
-            expectLastCurlCallForUrl(URL_BASE + "/latest");
+            expectLastCurlCallForUrl(URL_BASE + "/latest" + URL_TAIL);
         });
     });
 
@@ -166,7 +167,7 @@ describe('get latest release data', () => {
         expect(() => releases.getLatestReleaseData(21))
             .rejects
             .toThrow(error);
-        expectLastCurlCallForUrl(URL_BASE + "/latest");
+        expectLastCurlCallForUrl(URL_BASE + "/latest" + URL_TAIL);
     });
 
     describe('get latest release data with octokit', () => {
@@ -195,7 +196,7 @@ describe('get release by name', () => {
         const result = await releases.getReleaseDataByName('dummy-release-data');
         expect(result).toEqual(dummyReleaseData);
         // IMPORTANT: should not have a trailing slash
-        expectLastCurlCallForUrl(URL_BASE);
+        expectLastCurlCallForUrl(URL_BASE + URL_TAIL);
     });
 
     test('get release by name (non-existing)', async () => {
@@ -204,6 +205,6 @@ describe('get release by name', () => {
         const result = await releases.getReleaseDataByName('non-existing-data');
         expect(result).toBeUndefined();
         // IMPORTANT: should not have a trailing slash
-        expectLastCurlCallForUrl(URL_BASE);
+        expectLastCurlCallForUrl(URL_BASE + URL_TAIL);
     });
 });

--- a/__tests__/releases.test.ts
+++ b/__tests__/releases.test.ts
@@ -50,11 +50,14 @@ const dummyReleaseData_v1_28_0 = { ...dummyReleaseData, name: 'v1.28.0' };
 const allReleases = [dummyReleaseData, dummyReleaseData_1_7, dummyReleaseData_v1_24_0, dummyReleaseData_v1_28_0];
 
 const executor = jest.fn<CommandExecutor>();
+type Paginate = Octokit['paginate'];
 type ListReleases = Octokit['rest']['repos']['listReleases'];
 type GetLatestRelease = Octokit['rest']['repos']['getLatestRelease'];
+const mockPaginate = jest.fn<Paginate>();
 const mockListReleases = jest.fn<ListReleases>();
 const mockGetLatestRelease = jest.fn<GetLatestRelease>();
 const octokit = {
+    paginate: mockPaginate,
     rest: {
         repos: {
             listReleases: mockListReleases,
@@ -88,12 +91,7 @@ function mockApiReturnRelease(releaseData: ReleaseData) {
 }
 
 function mockOctokitReturnReleases() {
-    mockListReleases.mockReturnValueOnce(Promise.resolve({
-        headers: undefined as any,
-        status: 200,
-        url: '',
-        data: allReleases
-    }));
+    mockPaginate.mockReturnValueOnce(Promise.resolve(allReleases));
 }
 
 function mockOctokitReturnRelease(releaseData: ReleaseData) {
@@ -134,6 +132,7 @@ describe('get all release data', () => {
         const releases = new Releases(executor, octokit);
         const results = await releases.getAllReleaseData();
         expect(results).toEqual(allReleases);
+        expect(mockPaginate).toHaveBeenCalledWith(octokit.rest.repos.listReleases, { owner: "google", repo: "google-java-format", "per_page": 100 });
         expect(mockGetLatestRelease).not.toBeCalled();
         expect(executor).not.toBeCalled();
     });

--- a/dist/index.js
+++ b/dist/index.js
@@ -32722,8 +32722,8 @@ class Releases {
             return this.callReleasesApi();
         }
         const params = { owner: const_1.repositoryOwner, repo: const_1.repositoryName, per_page: 100 };
-        const response = await this.octokit.rest.repos.listReleases(params);
-        return response.data;
+        const allReleases = await this.octokit.paginate(this.octokit.rest.repos.listReleases, params);
+        return allReleases;
     }
     async getLatestReleaseData(javaVersion) {
         if (javaVersion < 11) {

--- a/dist/index.js
+++ b/dist/index.js
@@ -32713,7 +32713,7 @@ class Releases {
         this.octokit = octokit;
     }
     async callReleasesApi(pathParameter) {
-        const url = `${Releases.apiReleases}${pathParameter || ''}`;
+        const url = `${Releases.apiReleases}${pathParameter || ''}?per_page=100`;
         const response = await this.execute('curl', ['-sL', url], { ignoreReturnCode: false });
         return JSON.parse(response.stdOut);
     }
@@ -32721,7 +32721,7 @@ class Releases {
         if (!this.octokit) {
             return this.callReleasesApi();
         }
-        const params = { owner: const_1.repositoryOwner, repo: const_1.repositoryName };
+        const params = { owner: const_1.repositoryOwner, repo: const_1.repositoryName, per_page: 100 };
         const response = await this.octokit.rest.repos.listReleases(params);
         return response.data;
     }

--- a/src/releases.ts
+++ b/src/releases.ts
@@ -44,6 +44,10 @@ export class Releases {
             // Versions after v1.24.0 require JDK 17+
             return (await this.getReleaseDataByName('v1.24.0'))!;
         }
+        if (javaVersion < 21) {
+            // Versions after v1.28.0 require JDK 21+
+            return (await this.getReleaseDataByName('v1.28.0'))!;
+        }
         if (!this.octokit) {
             return this.callReleasesApi('/latest');
         }

--- a/src/releases.ts
+++ b/src/releases.ts
@@ -21,7 +21,7 @@ export class Releases {
     private async callReleasesApi(pathParameter: string | number): Promise<ReleaseData>;
     private async callReleasesApi(pathParameter?: number): Promise<ReleaseData | ReleaseData[]>;
     private async callReleasesApi(pathParameter?: string | number): Promise<ReleaseData | ReleaseData[]> {
-        const url = `${Releases.apiReleases}${pathParameter || ''}`;
+        const url = `${Releases.apiReleases}${pathParameter || ''}?per_page=100`;
         const response = await this.execute('curl', ['-sL', url], { ignoreReturnCode: false });
         return JSON.parse(response.stdOut);
     }
@@ -30,7 +30,7 @@ export class Releases {
         if (!this.octokit) {
             return this.callReleasesApi();
         }
-        const params = { owner: GJF_REPO_OWNER, repo: GJF_REPO_NAME };
+        const params = { owner: GJF_REPO_OWNER, repo: GJF_REPO_NAME, per_page: 100 };
         const response = await this.octokit.rest.repos.listReleases(params);
         return response.data;
     }

--- a/src/releases.ts
+++ b/src/releases.ts
@@ -31,8 +31,8 @@ export class Releases {
             return this.callReleasesApi();
         }
         const params = { owner: GJF_REPO_OWNER, repo: GJF_REPO_NAME, per_page: 100 };
-        const response = await this.octokit.rest.repos.listReleases(params);
-        return response.data;
+        const allReleases = await this.octokit.paginate(this.octokit.rest.repos.listReleases, params);
+        return allReleases;
     }
 
     async getLatestReleaseData(javaVersion: number): Promise<ReleaseData> {


### PR DESCRIPTION
This action isn't able to run on Java 8 because it only sees the Github API's default of the 30 latest formatter releases. There are 42 releases currently, and the list cuts off at version 1.11.0 (JDK 11+).

This branch starts with the commits from #40, then increases the number of releases requested so any release can be used with the action:
- when getting releases with curl, add `?per_page=100` (the maximum) to the end of everything
- when listing releases with Octokit, use 100-length pages, and paginate

The curl version is clunky, but the API allows page length even for _/latest_:
- https://api.github.com/repos/google/google-java-format/releases?per_page=100
- https://api.github.com/repos/google/google-java-format/releases/latest?per_page=100

I think it could be possible to use Octokit in the no-token case, too, with something like this: https://github.com/j-emmel/googlejavaformat-action/commit/a409c3ba6dc61c30a6cc7f9a959a62895e055855


Resolves: https://github.com/axel-op/googlejavaformat-action/issues/39
Resolves: https://github.com/axel-op/googlejavaformat-action/issues/44
